### PR TITLE
Put back check for sudden rising edge

### DIFF
--- a/Arduino_code/Arduino_code.ino
+++ b/Arduino_code/Arduino_code.ino
@@ -138,7 +138,7 @@ ISR(TIMER2_COMPA_vect){
 
       // If the number of positive slopes and their accumulated value are greater than
       // these respective thresholds, we say that we have found the positive edge of the phototransistor response
-      if( ( count_pos_slopes >= THRESH_COUNT_SLOPES &&  acc_pos_slopes > threshold )
+      if ( ( ( count_pos_slopes >= THRESH_COUNT_SLOPES &&  acc_pos_slopes > threshold ) || current_slope > threshold)
           && !flag_detected && sample_counter >= i_ledON)
       {
         count_pos_slopes = 0;


### PR DESCRIPTION
As discussed in #6, put back the check for a sudden increase in brightness from one sample to the next. 0.00ms now displays when the PT and LED are right next to each other.

Closes #6 