### PR TITLE
Fix line in setup() that initializes i_ledOFF incorrectly

### DIFF
--- a/Arduino_code/Arduino_code.ino
+++ b/Arduino_code/Arduino_code.ino
@@ -68,7 +68,7 @@ void setup() {
   randomSeed(randomSeedVal);
   
   i_ledON = random( 50, NUM_SAMPLES * 0.1 );  // Setting constrained random start time of the LED
-  i_ledOFF = random( i_ledON + 10, NUM_SAMPLES*0.9 );  // Setting constrained random end time of the LED
+  i_ledOFF = random( NUM_SAMPLES*0.85, NUM_SAMPLES*0.95 );  // Setting constrained random end time of the LED
   
   setup_msmt_timer1();
   setup_sampling_timer2();


### PR DESCRIPTION
I missed this line, it's related to the randomness so I'm linking it to #3. If you intentionally made it different in setup() than how it behaves in loop() however, feel free to close this.