### PR TITLE
Highlight colors in black diff in CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: rickstaa/action-black@v1
         with:
-          black_args: ". --check --diff --line-length 120"
+          black_args: ". --check --diff --line-length 120 --color"

--- a/delayrecorder.py
+++ b/delayrecorder.py
@@ -214,16 +214,7 @@ def plot_results(measurements: List[float], stats: Stats, png_file: Path) -> Non
     )
     textstr2 = "\n".join((r"$\mu=%.2f$" % (stats.mean_delay,), r"$\sigma=%.2f$" % (stats.std_dev,)))
     # place it at position x=0.95, y=0.90, relative to the top and right of the box
-    ax.text(
-        0.95,
-        0.95,
-        textstr2,
-        transform=ax.transAxes,
-        fontsize=14,
-        verticalalignment="top",
-        horizontalalignment="right",
-        bbox=props,
-    )
+    ax.text( 0.95, 0.95, textstr2, transform=ax.transAxes, fontsize=14, verticalalignment="top", horizontalalignment="right", bbox=props)
 
     plt.savefig(png_file)
     print(f"Saved histogram to {png_file}")

--- a/delayrecorder.py
+++ b/delayrecorder.py
@@ -214,7 +214,16 @@ def plot_results(measurements: List[float], stats: Stats, png_file: Path) -> Non
     )
     textstr2 = "\n".join((r"$\mu=%.2f$" % (stats.mean_delay,), r"$\sigma=%.2f$" % (stats.std_dev,)))
     # place it at position x=0.95, y=0.90, relative to the top and right of the box
-    ax.text( 0.95, 0.95, textstr2, transform=ax.transAxes, fontsize=14, verticalalignment="top", horizontalalignment="right", bbox=props)
+    ax.text(
+        0.95,
+        0.95,
+        textstr2,
+        transform=ax.transAxes,
+        fontsize=14,
+        verticalalignment="top",
+        horizontalalignment="right",
+        bbox=props,
+    )
 
     plt.savefig(png_file)
     print(f"Saved histogram to {png_file}")


### PR DESCRIPTION
@vashmata [wrote](https://github.com/cbachhuber/G2GDelay/pull/19#issuecomment-963124452):

> I can't make the change myself but you could add `--color` to the command and it will highlight the diff in color (red and green in my case) if the code needs to be formatted

Let's see if GitHub's CI can do color 👍 